### PR TITLE
docs: match version guidance in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ see the Navigation SDK for iOS
 3.  Select the version of the Navigation SDK for iOS that you want to use. For
     new projects, we recommend specifying the
     [latest version](https://developers.google.com/maps/documentation/navigation/ios-sdk/release-notes)
-    and using the "Up to Next Major Version" option.
+    and using the "Exact Version" option.
 
 4.  Follow the
     [instructions](https://developers.google.com/maps/documentation/navigation/ios-sdk/config#add-an-api-key-to-your-project)


### PR DESCRIPTION
As our versions guidance suggests, don't depend on SDKs to always respect semantic versioning.